### PR TITLE
Adds fixed version for reproducible builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import setuptools
 from datetime import datetime
 
-current_version = datetime.utcnow().strftime("%Y.%m")
+# Fixed version will help for reproducible builds
+current_version = "2023.3"
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Now we can rebuild the source into a wheel in any time in future, and we will still have the correct version of the project in the METADATA in wheel.